### PR TITLE
Restore VimtexOutputToggleFocus command

### DIFF
--- a/lua/snacks-vimtex-output/init.lua
+++ b/lua/snacks-vimtex-output/init.lua
@@ -670,13 +670,16 @@ function M.setup()
 	})
 
 	vim.api.nvim_create_user_command("VimtexOutputShow", function()
-		M.toggle_focus()
+		M.show()
 	end, {})
 	vim.api.nvim_create_user_command("VimtexOutputHide", function()
 		M.hide()
 	end, {})
 	vim.api.nvim_create_user_command("VimtexOutputToggle", function()
 		M.toggle()
+	end, {})
+	vim.api.nvim_create_user_command("VimtexOutputToggleFocus", function()
+		M.toggle_focus()
 	end, {})
 end
 


### PR DESCRIPTION
## Summary
- correct the VimtexOutputShow user command to actually show the floating window
- add back the missing VimtexOutputToggleFocus command so users can toggle focus

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c54d5959883288cc92a51bda6a70c)