### PR TITLE
Add Esc shortcut to exit focus overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ still available:
 | `:VimtexOutputToggleFocus` | Switch between mini/focus layouts. |
 | `:VimtexOutputToggleFollow` | Toggle follow/tail mode. |
 
+Press `<Esc>` while focused to drop back to the compact mini overlay without closing
+the panel.
+
 The overlay attaches to VimTeX's compiler log (usually the `latexmk` stdout
 buffer) and retains all prior behaviours—auto-open on compilation, optional
 auto-hide on success, green/red borders, and persistent error notifications.


### PR DESCRIPTION
## Summary
- add a focus-mode Esc keymap that returns the panel to mini mode
- document the Escape shortcut for VimTeX output windows

## Testing
- stylua lua/


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f65bd5bdc8328838f46eb13f6a836)